### PR TITLE
Fixing typos and pathPrefix for root.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const filterPages = (posts, pageLength) => {
 const getPageIndex = index => (index === 0 ? "" : index + 1);
 
 const buildPaginationRoute = (index, pathPrefix) => {
-  return index > 1 ? `${pathPrefix}/${index}` : '/'
+  return index > 1 ? `${pathPrefix}/${index}` : `/${pathPrefix}`
 }
 
 const isFirstPage = index => (index === 0 ? true : false);


### PR DESCRIPTION
Two changes.
1. Removed left over code. 

2. buildPaginationRoute does not work for my use case.
In my use case. I have the blog at example.com/blog.
So in gatsby-node.js, I pass "blog" as the pathPrefix in createPaginatedPages, like below. 
 createPaginatedPages({
            edges: posts,
            createPage: createPage,
            pageTemplate: "src/templates/blog.js",
            pageLength: 10,
            pathPrefix: "blog"
          });

The corresponding pages can be in example.com/blog/2 and so on.

Now, the question is if pathPrefix is for the root path or the prefix for the second page and so on, like below 

example.com/blog/page/2.
Which could also be a valid use case.